### PR TITLE
Use a real SQLite db for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@prisma/client": "^4.12.0",
+        "date-fns": "^2.30.0",
         "electron-log": "^4.4.8",
         "electron-squirrel-startup": "^1.0.0",
         "pinia": "^2.0.32",
@@ -61,6 +62,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -4173,10 +4185,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-      "dev": true,
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
       "engines": {
         "node": ">=0.11"
       },
@@ -9906,6 +9920,11 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@prisma/client": "^4.12.0",
+    "date-fns": "^2.30.0",
     "electron-log": "^4.4.8",
     "electron-squirrel-startup": "^1.0.0",
     "pinia": "^2.0.32",

--- a/prisma/migrations/20230520140919_remove_unique_constraints/migration.sql
+++ b/prisma/migrations/20230520140919_remove_unique_constraints/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "EnglishAnswer_englishCardSideId_key";
+
+-- DropIndex
+DROP INDEX "JapaneseAnswer_japaneseCardSideId_key";

--- a/prisma/prisma.ts
+++ b/prisma/prisma.ts
@@ -73,7 +73,7 @@ function getDbUrl() {
   if (isDev) {
     return process.env.DATABASE_URL
   } else if (isTest) {
-    return 'file:../test.db?socket_timeout=200&connection_limit=1'
+    return 'file:../test.db?connection_limit=1'
   } else {
     const dbPath = path.join(app.getPath('userData'), 'app.db')
     return 'file:' + dbPath

--- a/prisma/queries/__tests__/getReviewableCards.spec.ts
+++ b/prisma/queries/__tests__/getReviewableCards.spec.ts
@@ -1,41 +1,122 @@
-import { describe, expect, it, vi } from 'vitest'
-import { prisma as mockPrisma } from '../../__mocks__/prisma'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import getReviewableCards from '../getReviewableCards'
-
-vi.mock('../../prisma.ts')
+import { prisma } from 'prisma/prisma'
+import { add, sub } from 'date-fns'
+import resetDatabase from 'utils/testHelpers/resetDatabase'
 
 describe('getReviewableCards', () => {
   describe('when the request succeeds', () => {
-    it('returns all reviewable cards', async () => {
-      const card = {
-        id: '1',
-        createdAt: new Date('2023-05-10'),
-        updatedAt: new Date('2023-05-10'),
-      }
+    beforeEach(async () => {
+      await resetDatabase()
+    })
 
-      mockPrisma.card.findMany.mockResolvedValue([card])
+    describe('and there is an english card side that should be reviewed', () => {
+      it('returns the card', async () => {
+        const past = sub(new Date(), { weeks: 1 })
+        const future = add(new Date(), { weeks: 1 })
+        const catCard = await createCard('cat', 'ねこ', '猫', past, future)
 
-      const response = await getReviewableCards()
+        const response = await getReviewableCards()
 
-      expect(response.data).toBeDefined()
-      expect(response.data!.length).toEqual(1)
-      expect(response.data!).toEqual([card])
+        expect(response.data).toBeDefined()
+        expect(response.data!.length).toEqual(1)
+        expect(response.data![0].id).toEqual(catCard.id)
+      })
+    })
+
+    describe('and there is a japanese card side that should be reviewed', () => {
+      it('returns the card', async () => {
+        const past = sub(new Date(), { weeks: 1 })
+        const future = add(new Date(), { weeks: 1 })
+        const catCard = await createCard('cat', 'ねこ', '猫', future, past)
+
+        const response = await getReviewableCards()
+
+        expect(response.data).toBeDefined()
+        expect(response.data!.length).toEqual(1)
+        expect(response.data![0].id).toEqual(catCard.id)
+      })
+    })
+
+    describe('and both sides should be reviewed', () => {
+      it('only returns one card', async () => {
+        const past = sub(new Date(), { weeks: 1 })
+        await createCard('cat', 'ねこ', '猫', past, past)
+
+        const response = await getReviewableCards()
+
+        expect(response.data).toBeDefined()
+        expect(response.data!.length).toEqual(1)
+      })
+    })
+
+    describe('and no cards should be reviewed', () => {
+      it('returns nothing', async () => {
+        const future = add(new Date(), { weeks: 1 })
+        await createCard('cat', 'ねこ', '猫', future, future)
+
+        const response = await getReviewableCards()
+
+        expect(response.data).toBeDefined()
+        expect(response.data!.length).toEqual(0)
+      })
     })
   })
 
   describe('when the request fails', () => {
+    beforeEach(() => {
+      vi.doMock('../../prisma.ts')
+      vi.resetModules()
+    })
     describe('with an error object', () => {
       it('returns as error', async () => {
+        const { prisma: mockPrisma } = await import('../../__mocks__/prisma')
+        const { default: mockedGetReviewableCards } = await import('../getReviewableCards')
+
         const returnedError = new Error('oh no')
 
         mockPrisma.card.findMany.mockImplementation(() => {
           throw returnedError
         })
 
-        const response = await getReviewableCards()
+        const response = await mockedGetReviewableCards()
 
         expect(response.error).toEqual(returnedError)
       })
     })
   })
 })
+
+async function createCard(
+  english: string,
+  kana: string,
+  kanji: string,
+  englishNextReviewAt: Date,
+  japaneseNextReviewAt: Date,
+) {
+  return await prisma.card.create({
+    data: {
+      englishCardSide: {
+        create: {
+          nextReviewAt: englishNextReviewAt,
+          englishAnswers: {
+            create: {
+              answer: english,
+            },
+          },
+        },
+      },
+      japaneseCardSide: {
+        create: {
+          nextReviewAt: japaneseNextReviewAt,
+          japaneseAnswers: {
+            create: {
+              kana,
+              kanji,
+            },
+          },
+        },
+      },
+    },
+  })
+}

--- a/prisma/queries/__tests__/searchCards.spec.ts
+++ b/prisma/queries/__tests__/searchCards.spec.ts
@@ -1,74 +1,22 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
 
-import searchCards from '../searchCards'
-import { prisma as mockPrisma } from '../../__mocks__/prisma'
-import type { Card } from '@prisma/client'
-
-vi.mock('../../prisma.ts')
+import searchCards, { includeAllCardRelationships } from '../searchCards'
+import { prisma } from '../../prisma'
 
 describe('searchCards', () => {
+  beforeEach(async () => {
+    await prisma.$executeRawUnsafe('DELETE FROM EnglishAnswer;')
+    await prisma.$executeRawUnsafe('DELETE FROM JapaneseAnswer;')
+    await prisma.$executeRawUnsafe('DELETE FROM JapaneseCardSide;')
+    await prisma.$executeRawUnsafe('DELETE FROM EnglishCardSide;')
+    await prisma.$executeRawUnsafe('DELETE FROM Card;')
+  })
+
   describe('when a query is supplied', () => {
     it('searches for the card that matches the query', async () => {
-      const card: Card = {
-        id: '1',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }
-      mockPrisma.card.findMany.mockResolvedValue([card])
+      const card = await createCard('cat', 'ねこ', '猫')
 
       const response = await searchCards({} as Event, { query: 'cat' })
-
-      expect(mockPrisma.card.findMany).toBeCalledWith({
-        where: {
-          OR: [
-            {
-              japaneseCardSide: {
-                japaneseAnswers: {
-                  some: {
-                    kana: {
-                      contains: 'cat',
-                    },
-                  },
-                },
-              },
-            },
-            {
-              japaneseCardSide: {
-                japaneseAnswers: {
-                  some: {
-                    kanji: {
-                      contains: 'cat',
-                    },
-                  },
-                },
-              },
-            },
-            {
-              englishCardSide: {
-                englishAnswers: {
-                  some: {
-                    answer: {
-                      contains: 'cat',
-                    },
-                  },
-                },
-              },
-            },
-          ],
-        },
-        include: {
-          englishCardSide: {
-            include: {
-              englishAnswers: true,
-            },
-          },
-          japaneseCardSide: {
-            include: {
-              japaneseAnswers: true,
-            },
-          },
-        },
-      })
 
       expect(response).toEqual({ data: [card] })
     })
@@ -76,35 +24,59 @@ describe('searchCards', () => {
 
   describe('when a query is not supplied', () => {
     it('returns all cards', async () => {
-      await searchCards({} as Event)
+      const catCard = await createCard('cat', 'ねこ', '猫')
+      const dogCard = await createCard('dog', 'いぬ', '犬')
+      const response = await searchCards({} as Event)
 
-      expect(mockPrisma.card.findMany).toBeCalledWith({
-        include: {
-          englishCardSide: {
-            include: {
-              englishAnswers: true,
-            },
-          },
-          japaneseCardSide: {
-            include: {
-              japaneseAnswers: true,
-            },
-          },
-        },
-      })
+      expect(response).toEqual({ data: [catCard, dogCard] })
     })
   })
 
   describe('when the request fails', () => {
+    beforeEach(() => {
+      vi.doMock('../../prisma.ts')
+      vi.resetModules()
+    })
+
     it('returns the error', async () => {
+      const { prisma: mockPrisma } = await import('../../__mocks__/prisma')
+      const { default: mockedSearchCards } = await import('../searchCards')
+
       const returnedError = new Error('oh no')
       mockPrisma.card.findMany.mockImplementation(() => {
         throw returnedError
       })
 
-      const response = await searchCards({} as Event)
+      const response = await mockedSearchCards({} as Event)
 
       expect(response).toEqual({ error: returnedError })
     })
   })
 })
+
+async function createCard(english: string, kana?: string, kanji?: string) {
+  return await prisma.card.create({
+    data: {
+      japaneseCardSide: {
+        create: {
+          japaneseAnswers: {
+            create: {
+              kana,
+              kanji,
+            },
+          },
+        },
+      },
+      englishCardSide: {
+        create: {
+          englishAnswers: {
+            create: {
+              answer: english,
+            },
+          },
+        },
+      },
+    },
+    include: includeAllCardRelationships,
+  })
+}

--- a/prisma/queries/__tests__/searchCards.spec.ts
+++ b/prisma/queries/__tests__/searchCards.spec.ts
@@ -2,14 +2,11 @@ import { describe, expect, it, beforeEach, vi } from 'vitest'
 
 import searchCards, { includeAllCardRelationships } from '../searchCards'
 import { prisma } from '../../prisma'
+import resetDatabase from 'utils/testHelpers/resetDatabase'
 
 describe('searchCards', () => {
   beforeEach(async () => {
-    await prisma.$executeRawUnsafe('DELETE FROM EnglishAnswer;')
-    await prisma.$executeRawUnsafe('DELETE FROM JapaneseAnswer;')
-    await prisma.$executeRawUnsafe('DELETE FROM JapaneseCardSide;')
-    await prisma.$executeRawUnsafe('DELETE FROM EnglishCardSide;')
-    await prisma.$executeRawUnsafe('DELETE FROM Card;')
+    await resetDatabase()
   })
 
   describe('when a query is supplied', () => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,7 +32,7 @@ model JapaneseAnswer {
   createdAt          DateTime         @default(now())
   updatedAt          DateTime         @updatedAt
   japaneseCardSide   JapaneseCardSide @relation(fields: [japaneseCardSideId], references: [id])
-  japaneseCardSideId String           @unique
+  japaneseCardSideId String
 }
 
 model EnglishCardSide {
@@ -51,5 +51,5 @@ model EnglishAnswer {
   createdAt         DateTime        @default(now())
   updatedAt         DateTime        @updatedAt
   englishCardSide   EnglishCardSide @relation(fields: [englishCardSideId], references: [id])
-  englishCardSideId String          @unique
+  englishCardSideId String
 }

--- a/testSetup.js
+++ b/testSetup.js
@@ -11,7 +11,10 @@ if (!dbExists) {
   fs.closeSync(fs.openSync(dbPath, 'w'))
 }
 
-exec('DATABASE_URL=file:../test.db npx prisma migrate reset --force', (stdout, stderr) => {
-  console.log('stdout:', stdout)
-  console.log('stderr:', stderr)
-})
+exec(
+  'DATABASE_URL=file:../test.db npx prisma migrate reset --force --skip-seed',
+  (stdout, stderr) => {
+    console.log('stdout:', stdout)
+    console.log('stderr:', stderr)
+  },
+)

--- a/utils/testHelpers/resetDatabase.ts
+++ b/utils/testHelpers/resetDatabase.ts
@@ -1,0 +1,9 @@
+import { prisma } from '../../prisma/prisma'
+
+export default async function resetDatabase() {
+  await prisma.$executeRawUnsafe('DELETE FROM EnglishAnswer;')
+  await prisma.$executeRawUnsafe('DELETE FROM JapaneseAnswer;')
+  await prisma.$executeRawUnsafe('DELETE FROM JapaneseCardSide;')
+  await prisma.$executeRawUnsafe('DELETE FROM EnglishCardSide;')
+  await prisma.$executeRawUnsafe('DELETE FROM Card;')
+}


### PR DESCRIPTION
I didn't really like mocking out the prisma integration, because then I'm just really testing that the mock was set up correctly. Case in point I discovered an issue with unnecessary unique constraints preventing multiple answers from being created, which was not something the typesystem or the mock picked up.